### PR TITLE
Claims meshing

### DIFF
--- a/src/main/java/org/dynmap/forge/integration/ServerUtilitiesClaimedChunksMarkers.java
+++ b/src/main/java/org/dynmap/forge/integration/ServerUtilitiesClaimedChunksMarkers.java
@@ -83,31 +83,7 @@ public class ServerUtilitiesClaimedChunksMarkers extends DynmapCommonAPIListener
             double[] z = new double[]{pos.posZ*16, pos.posZ*16+16};
 
             ForgeTeam team = cc.getTeam();
-            String teamName = team.getId();
-//            String title = team.getTitle().getUnformattedText();
-//            if (title != null && !teamName.equals(""))
-//                teamName = "[" + title + "] " + teamName;
-            String label = "Claimed by <b>"+ teamName +"</b>";
-            String desc = team.getDesc();
-            if(desc != null && !desc.equals(""))
-                label += "<br/><i>" + team.getDesc() + "</i>";
-
-            if(team.owner != null)
-                label += "<br/><b>Founder: </b>" + team.owner.getName();
-
-            List<ForgePlayer> members = team.getMembers();
-            if(members != null){
-                for(ForgePlayer m : members){
-                    if(m != team.owner)
-                        label += "<br/>Member: " + m.getName();
-                }
-            }
-
-            if(team.players != null){
-                for(Map.Entry<ForgePlayer, EnumTeamStatus> p : team.players.entrySet()){
-                    label += "<br/>" + p.getValue() + ": " +  p.getKey().getName();
-                }
-            }
+            String label = buildLabel(team);
 
             AreaMarker am = markerSet.createAreaMarker("c_" + (claimId++), label, true, worldId, x,z, false);
 
@@ -119,6 +95,36 @@ public class ServerUtilitiesClaimedChunksMarkers extends DynmapCommonAPIListener
         }
 
         updateNeeded = false;
+    }
+
+    private static String buildLabel(ForgeTeam team) {
+        String teamName = team.getId();
+//        String title = team.getTitle().getUnformattedText();
+//        if (title != null && !teamName.equals(""))
+//            teamName = "[" + title + "] " + teamName;
+        String label = "Claimed by <b>" + teamName + "</b>";
+        String desc = team.getDesc();
+        if(desc != null && !desc.equals(""))
+            label += "<br/><i>" + team.getDesc() + "</i>";
+
+        if(team.owner != null)
+            label += "<br/><b>Founder: </b>" + team.owner.getName();
+
+        List<ForgePlayer> members = team.getMembers();
+        if(members != null){
+            for(ForgePlayer m : members){
+                if(m != team.owner)
+                    label += "<br/>Member: " + m.getName();
+            }
+        }
+
+        if(team.players != null){
+            for(Map.Entry<ForgePlayer, EnumTeamStatus> p : team.players.entrySet()){
+                label += "<br/>" + p.getValue() + ": " +  p.getKey().getName();
+            }
+        }
+
+        return label;
     }
 
     @SubscribeEvent

--- a/src/main/java/org/dynmap/forge/integration/ServerUtilitiesClaimedChunksMarkers.java
+++ b/src/main/java/org/dynmap/forge/integration/ServerUtilitiesClaimedChunksMarkers.java
@@ -16,6 +16,7 @@ import org.dynmap.forge.GwmSubCommand;
 import org.dynmap.markers.AreaMarker;
 import org.dynmap.markers.MarkerAPI;
 import org.dynmap.markers.MarkerSet;
+import org.dynmap.utils.GreedyRectangleMesher;
 import serverutils.ServerUtilitiesConfig;
 import serverutils.data.ClaimedChunk;
 import serverutils.data.ClaimedChunks;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ServerUtilitiesClaimedChunksMarkers extends DynmapCommonAPIListener {
+    private static final int CHUNK_SIZE = 16;
 
     static ServerUtilitiesClaimedChunksMarkers INSTANCE;
     MarkerSet markerSet;
@@ -70,6 +72,7 @@ public class ServerUtilitiesClaimedChunksMarkers extends DynmapCommonAPIListener
             return;
 
         int claimId = 1;
+        HashMap<ClaimGroupKey, ClaimGroup> claimsByGroup = new HashMap<>();
 
         for(ClaimedChunk cc : ClaimedChunks.instance.getAllChunks()){
             ChunkDimPos pos = cc.getPos();
@@ -79,19 +82,26 @@ public class ServerUtilitiesClaimedChunksMarkers extends DynmapCommonAPIListener
             if(worldId == null)
                 continue;
 
-            double[] x = new double[]{pos.posX*16, pos.posX*16+16};
-            double[] z = new double[]{pos.posZ*16, pos.posZ*16+16};
-
             ForgeTeam team = cc.getTeam();
-            String label = buildLabel(team);
+            ClaimGroupKey key = new ClaimGroupKey(worldId, team.getId());
+            ClaimGroup group = claimsByGroup.computeIfAbsent(key,
+                    ignored -> new ClaimGroup(worldId, buildLabel(team), team.getColor().getColor().rgb()));
+            group.chunks.add(GreedyRectangleMesher.pack(pos.posX, pos.posZ));
+        }
 
-            AreaMarker am = markerSet.createAreaMarker("c_" + (claimId++), label, true, worldId, x,z, false);
+        for(ClaimGroup group : claimsByGroup.values()) {
+            for(GreedyRectangleMesher.Rectangle rectangle : GreedyRectangleMesher.mesh(group.chunks)) {
+                double[] x = new double[]{rectangle.x1 * CHUNK_SIZE, rectangle.x2 * CHUNK_SIZE};
+                double[] z = new double[]{rectangle.y1 * CHUNK_SIZE, rectangle.y2 * CHUNK_SIZE};
 
-            if(GwmConfig.boostServerUtilitiesClaimsMarkers)
-                am.setBoostFlag(true);
+                AreaMarker am = markerSet.createAreaMarker("c_" + (claimId++), group.label, true, group.worldId, x, z, false);
 
-            am.setLineStyle(0,0,0);
-            am.setFillStyle(0.2, team.getColor().getColor().rgb());
+                if(GwmConfig.boostServerUtilitiesClaimsMarkers)
+                    am.setBoostFlag(true);
+
+                am.setLineStyle(0,0,0);
+                am.setFillStyle(0.2, group.fillColor);
+            }
         }
 
         updateNeeded = false;
@@ -123,8 +133,46 @@ public class ServerUtilitiesClaimedChunksMarkers extends DynmapCommonAPIListener
                 label += "<br/>" + p.getValue() + ": " +  p.getKey().getName();
             }
         }
-
         return label;
+    }
+
+    private static class ClaimGroupKey {
+        final String worldId;
+        final String teamId;
+
+        private ClaimGroupKey(String worldId, String teamId) {
+            this.worldId = worldId;
+            this.teamId = teamId;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if(this == obj)
+                return true;
+            if(!(obj instanceof ClaimGroupKey))
+                return false;
+
+            ClaimGroupKey other = (ClaimGroupKey) obj;
+            return worldId.equals(other.worldId) && teamId.equals(other.teamId);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * worldId.hashCode() + teamId.hashCode();
+        }
+    }
+
+    private static class ClaimGroup {
+        final String worldId;
+        final String label;
+        final int fillColor;
+        final java.util.HashSet<Long> chunks = new java.util.HashSet<Long>();
+
+        private ClaimGroup(String worldId, String label, int fillColor) {
+            this.worldId = worldId;
+            this.label = label;
+            this.fillColor = fillColor;
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/org/dynmap/forge/integration/ServerUtilitiesClaimedChunksMarkers.java
+++ b/src/main/java/org/dynmap/forge/integration/ServerUtilitiesClaimedChunksMarkers.java
@@ -27,6 +27,7 @@ import serverutils.lib.data.ForgeTeam;
 import serverutils.lib.math.ChunkDimPos;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -166,7 +167,7 @@ public class ServerUtilitiesClaimedChunksMarkers extends DynmapCommonAPIListener
         final String worldId;
         final String label;
         final int fillColor;
-        final java.util.HashSet<Long> chunks = new java.util.HashSet<Long>();
+        final HashSet<Long> chunks = new HashSet<>();
 
         private ClaimGroup(String worldId, String label, int fillColor) {
             this.worldId = worldId;

--- a/src/main/java/org/dynmap/utils/GreedyRectangleMesher.java
+++ b/src/main/java/org/dynmap/utils/GreedyRectangleMesher.java
@@ -2,17 +2,22 @@ package org.dynmap.utils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * Adapted from jetp250's 2D greedy meshing gist:
  * https://gist.github.com/jetp250/9ca4d583f7f387bc4a2665e001b0c8fd
  *
- * This version emits rectangles for filled cells in an arbitrary bounding box,
- * rather than for empty cells in a fixed-size chunk-local grid.
+ * This version emits rectangles for filled cells and meshes them tile-by-tile
+ * to keep memory usage bounded for sparse, far-apart claims.
  */
 public final class GreedyRectangleMesher {
+    public static final int TILE_SIZE = 256;
+    private static final int TILE_AREA = TILE_SIZE * TILE_SIZE;
+
     private GreedyRectangleMesher() {
     }
 
@@ -25,52 +30,44 @@ public final class GreedyRectangleMesher {
             return Collections.emptyList();
         }
 
-        int minX = Integer.MAX_VALUE;
-        int minY = Integer.MAX_VALUE;
-        int maxX = Integer.MIN_VALUE;
-        int maxY = Integer.MIN_VALUE;
-
+        Map<Long, byte[]> tileMaps = new HashMap<Long, byte[]>();
         for(long cell : cells) {
             int x = unpackX(cell);
             int y = unpackY(cell);
-            if(x < minX) minX = x;
-            if(y < minY) minY = y;
-            if(x > maxX) maxX = x;
-            if(y > maxY) maxY = y;
+            int tileX = Math.floorDiv(x, TILE_SIZE);
+            int tileY = Math.floorDiv(y, TILE_SIZE);
+            int localX = Math.floorMod(x, TILE_SIZE);
+            int localY = Math.floorMod(y, TILE_SIZE);
+
+            long tileKey = pack(tileX, tileY);
+            byte[] map = tileMaps.get(tileKey);
+            if(map == null) {
+                map = new byte[TILE_AREA];
+                tileMaps.put(tileKey, map);
+            }
+
+            map[localX + localY * TILE_SIZE] = 1;
         }
 
-        int width = maxX - minX + 1;
-        int height = maxY - minY + 1;
-        byte[] map = new byte[width * height];
-
-        for(long cell : cells) {
-            int x = unpackX(cell) - minX;
-            int y = unpackY(cell) - minY;
-            map[x + y * width] = 1;
+        List<Rectangle> rectangles = new ArrayList<Rectangle>();
+        short[] skipMap = new short[TILE_AREA];
+        for(Map.Entry<Long, byte[]> entry : tileMaps.entrySet()) {
+            int tileX = unpackX(entry.getKey());
+            int tileY = unpackY(entry.getKey());
+            rectangles.addAll(greedyMesh(entry.getValue(), skipMap, tileX * TILE_SIZE, tileY * TILE_SIZE));
         }
-
-        List<Rectangle> rectangles = greedyMesh(map, width, height);
-        for(int i = 0; i < rectangles.size(); i++) {
-            Rectangle rectangle = rectangles.get(i);
-            rectangles.set(i, new Rectangle(
-                    rectangle.x1 + minX,
-                    rectangle.y1 + minY,
-                    rectangle.x2 + minX,
-                    rectangle.y2 + minY));
-        }
-
         return rectangles;
     }
 
-    private static List<Rectangle> greedyMesh(byte[] map, int width, int height) {
-        List<Rectangle> rectangles = new ArrayList<>();
-        int[] skipMap = new int[width * height];
+    private static List<Rectangle> greedyMesh(byte[] map, short[] skipMap, int xOffset, int yOffset) {
+        List<Rectangle> rectangles = new ArrayList<Rectangle>();
+        clear(skipMap);
 
-        for(int x1 = 0; x1 < width; ++x1) {
+        for(int x1 = 0; x1 < TILE_SIZE; ++x1) {
             int y1 = 0;
             int y2 = 0;
-            while(y2 < height) {
-                int idx = x1 + y2 * width;
+            while(y2 < TILE_SIZE) {
+                int idx = x1 + y2 * TILE_SIZE;
                 int skip = skipMap[idx];
                 if(skip == 0 && map[idx] != 0) {
                     y2 += 1;
@@ -84,11 +81,11 @@ public final class GreedyRectangleMesher {
                     continue;
                 }
 
-                int x2 = findRectangleX2(map, width, height, x1, y1, y2);
-                rectangles.add(new Rectangle(x1, y1, x2, y2));
+                int x2 = findRectangleX2(map, x1, y1, y2);
+                rectangles.add(new Rectangle(x1 + xOffset, y1 + yOffset, x2 + xOffset, y2 + yOffset));
 
                 for(int x = x1 + 1; x < x2; ++x) {
-                    skipMap[x + y1 * width] = y2 - y1;
+                    skipMap[x + y1 * TILE_SIZE] = (short) (y2 - y1);
                 }
 
                 y2 += Math.max(skip, 1);
@@ -96,11 +93,11 @@ public final class GreedyRectangleMesher {
             }
 
             if(y1 != y2) {
-                int x2 = findRectangleX2(map, width, height, x1, y1, y2);
-                rectangles.add(new Rectangle(x1, y1, x2, y2));
+                int x2 = findRectangleX2(map, x1, y1, y2);
+                rectangles.add(new Rectangle(x1 + xOffset, y1 + yOffset, x2 + xOffset, y2 + yOffset));
 
                 for(int x = x1 + 1; x < x2; ++x) {
-                    skipMap[x + y1 * width] = y2 - y1;
+                    skipMap[x + y1 * TILE_SIZE] = (short) (y2 - y1);
                 }
             }
         }
@@ -108,16 +105,22 @@ public final class GreedyRectangleMesher {
         return rectangles;
     }
 
-    private static int findRectangleX2(byte[] map, int width, int height, int x1, int y1, int y2) {
-        for(int x2 = x1 + 1; x2 < width; ++x2) {
+    private static int findRectangleX2(byte[] map, int x1, int y1, int y2) {
+        for(int x2 = x1 + 1; x2 < TILE_SIZE; ++x2) {
             for(int y = y1; y < y2; ++y) {
-                if(map[x2 + y * width] == 0) {
+                if(map[x2 + y * TILE_SIZE] == 0) {
                     return x2;
                 }
             }
         }
 
-        return width;
+        return TILE_SIZE;
+    }
+
+    private static void clear(short[] skipMap) {
+        for(int i = 0; i < TILE_AREA; ++i) {
+            skipMap[i] = 0;
+        }
     }
 
     private static int unpackX(long cell) {

--- a/src/main/java/org/dynmap/utils/GreedyRectangleMesher.java
+++ b/src/main/java/org/dynmap/utils/GreedyRectangleMesher.java
@@ -1,0 +1,144 @@
+package org.dynmap.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Adapted from jetp250's 2D greedy meshing gist:
+ * https://gist.github.com/jetp250/9ca4d583f7f387bc4a2665e001b0c8fd
+ *
+ * This version emits rectangles for filled cells in an arbitrary bounding box,
+ * rather than for empty cells in a fixed-size chunk-local grid.
+ */
+public final class GreedyRectangleMesher {
+    private GreedyRectangleMesher() {
+    }
+
+    public static long pack(int x, int y) {
+        return ((long) x << 32) | (y & 0xFFFFFFFFL);
+    }
+
+    public static List<Rectangle> mesh(Set<Long> cells) {
+        if(cells.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        int minX = Integer.MAX_VALUE;
+        int minY = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxY = Integer.MIN_VALUE;
+
+        for(long cell : cells) {
+            int x = unpackX(cell);
+            int y = unpackY(cell);
+            if(x < minX) minX = x;
+            if(y < minY) minY = y;
+            if(x > maxX) maxX = x;
+            if(y > maxY) maxY = y;
+        }
+
+        int width = maxX - minX + 1;
+        int height = maxY - minY + 1;
+        byte[] map = new byte[width * height];
+
+        for(long cell : cells) {
+            int x = unpackX(cell) - minX;
+            int y = unpackY(cell) - minY;
+            map[x + y * width] = 1;
+        }
+
+        List<Rectangle> rectangles = greedyMesh(map, width, height);
+        for(int i = 0; i < rectangles.size(); i++) {
+            Rectangle rectangle = rectangles.get(i);
+            rectangles.set(i, new Rectangle(
+                    rectangle.x1 + minX,
+                    rectangle.y1 + minY,
+                    rectangle.x2 + minX,
+                    rectangle.y2 + minY));
+        }
+
+        return rectangles;
+    }
+
+    private static List<Rectangle> greedyMesh(byte[] map, int width, int height) {
+        List<Rectangle> rectangles = new ArrayList<>();
+        int[] skipMap = new int[width * height];
+
+        for(int x1 = 0; x1 < width; ++x1) {
+            int y1 = 0;
+            int y2 = 0;
+            while(y2 < height) {
+                int idx = x1 + y2 * width;
+                int skip = skipMap[idx];
+                if(skip == 0 && map[idx] != 0) {
+                    y2 += 1;
+                    continue;
+                }
+
+                if(y1 == y2) {
+                    int advance = Math.max(skip, 1);
+                    y1 += advance;
+                    y2 += advance;
+                    continue;
+                }
+
+                int x2 = findRectangleX2(map, width, height, x1, y1, y2);
+                rectangles.add(new Rectangle(x1, y1, x2, y2));
+
+                for(int x = x1 + 1; x < x2; ++x) {
+                    skipMap[x + y1 * width] = y2 - y1;
+                }
+
+                y2 += Math.max(skip, 1);
+                y1 = y2;
+            }
+
+            if(y1 != y2) {
+                int x2 = findRectangleX2(map, width, height, x1, y1, y2);
+                rectangles.add(new Rectangle(x1, y1, x2, y2));
+
+                for(int x = x1 + 1; x < x2; ++x) {
+                    skipMap[x + y1 * width] = y2 - y1;
+                }
+            }
+        }
+
+        return rectangles;
+    }
+
+    private static int findRectangleX2(byte[] map, int width, int height, int x1, int y1, int y2) {
+        for(int x2 = x1 + 1; x2 < width; ++x2) {
+            for(int y = y1; y < y2; ++y) {
+                if(map[x2 + y * width] == 0) {
+                    return x2;
+                }
+            }
+        }
+
+        return width;
+    }
+
+    private static int unpackX(long cell) {
+        return (int) (cell >> 32);
+    }
+
+    private static int unpackY(long cell) {
+        return (int) cell;
+    }
+
+    public static final class Rectangle {
+        public final int x1;
+        public final int y1;
+        public final int x2;
+        public final int y2;
+
+        public Rectangle(int x1, int y1, int x2, int y2) {
+            this.x1 = x1;
+            this.y1 = y1;
+            this.x2 = x2;
+            this.y2 = y2;
+        }
+    }
+}

--- a/src/main/java/org/dynmap/utils/GreedyRectangleMesher.java
+++ b/src/main/java/org/dynmap/utils/GreedyRectangleMesher.java
@@ -1,6 +1,7 @@
 package org.dynmap.utils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -15,7 +16,7 @@ import java.util.Set;
  * to keep memory usage bounded for sparse, far-apart claims.
  */
 public final class GreedyRectangleMesher {
-    public static final int TILE_SIZE = 256;
+    private static final int TILE_SIZE = 256;
     private static final int TILE_AREA = TILE_SIZE * TILE_SIZE;
 
     private GreedyRectangleMesher() {
@@ -30,7 +31,7 @@ public final class GreedyRectangleMesher {
             return Collections.emptyList();
         }
 
-        Map<Long, byte[]> tileMaps = new HashMap<Long, byte[]>();
+        Map<Long, byte[]> tileMaps = new HashMap<>();
         for(long cell : cells) {
             int x = unpackX(cell);
             int y = unpackY(cell);
@@ -49,7 +50,7 @@ public final class GreedyRectangleMesher {
             map[localX + localY * TILE_SIZE] = 1;
         }
 
-        List<Rectangle> rectangles = new ArrayList<Rectangle>();
+        List<Rectangle> rectangles = new ArrayList<>();
         short[] skipMap = new short[TILE_AREA];
         for(Map.Entry<Long, byte[]> entry : tileMaps.entrySet()) {
             int tileX = unpackX(entry.getKey());
@@ -60,8 +61,8 @@ public final class GreedyRectangleMesher {
     }
 
     private static List<Rectangle> greedyMesh(byte[] map, short[] skipMap, int xOffset, int yOffset) {
-        List<Rectangle> rectangles = new ArrayList<Rectangle>();
-        clear(skipMap);
+        List<Rectangle> rectangles = new ArrayList<>();
+        Arrays.fill(skipMap, (short) 0);
 
         for(int x1 = 0; x1 < TILE_SIZE; ++x1) {
             int y1 = 0;
@@ -81,28 +82,28 @@ public final class GreedyRectangleMesher {
                     continue;
                 }
 
-                int x2 = findRectangleX2(map, x1, y1, y2);
-                rectangles.add(new Rectangle(x1 + xOffset, y1 + yOffset, x2 + xOffset, y2 + yOffset));
-
-                for(int x = x1 + 1; x < x2; ++x) {
-                    skipMap[x + y1 * TILE_SIZE] = (short) (y2 - y1);
-                }
+                emitRectangle(map, skipMap, rectangles, x1, y1, y2, xOffset, yOffset);
 
                 y2 += Math.max(skip, 1);
                 y1 = y2;
             }
 
             if(y1 != y2) {
-                int x2 = findRectangleX2(map, x1, y1, y2);
-                rectangles.add(new Rectangle(x1 + xOffset, y1 + yOffset, x2 + xOffset, y2 + yOffset));
-
-                for(int x = x1 + 1; x < x2; ++x) {
-                    skipMap[x + y1 * TILE_SIZE] = (short) (y2 - y1);
-                }
+                emitRectangle(map, skipMap, rectangles, x1, y1, y2, xOffset, yOffset);
             }
         }
 
         return rectangles;
+    }
+
+    private static void emitRectangle(byte[] map, short[] skipMap, List<Rectangle> rectangles,
+                                      int x1, int y1, int y2, int xOffset, int yOffset) {
+        int x2 = findRectangleX2(map, x1, y1, y2);
+        rectangles.add(new Rectangle(x1 + xOffset, y1 + yOffset, x2 + xOffset, y2 + yOffset));
+
+        for(int x = x1 + 1; x < x2; ++x) {
+            skipMap[x + y1 * TILE_SIZE] = (short) (y2 - y1);
+        }
     }
 
     private static int findRectangleX2(byte[] map, int x1, int y1, int y2) {
@@ -115,12 +116,6 @@ public final class GreedyRectangleMesher {
         }
 
         return TILE_SIZE;
-    }
-
-    private static void clear(short[] skipMap) {
-        for(int i = 0; i < TILE_AREA; ++i) {
-            skipMap[i] = 0;
-        }
     }
 
     private static int unpackX(long cell) {


### PR DESCRIPTION
The webmap can display SU claimed chunks as overlay. Currently each claimed chunk gets rendered as html element, which is bad for performance if you have a lot.
This PR implements greedy meshing for those rectangles, cutting down the number of drawn overlays by a lot. Meshing is based on https://gist.github.com/jetp250/9ca4d583f7f387bc4a2665e001b0c8fd (WTFPL) and adapted for our usecase.
We mesh in 256x256 chunk tiles to keep memory usage in check.

Created with help of AI (codex), reviewed and directed by me. Seems to work just fine in my testing.